### PR TITLE
Fix file type import conflict in DocumentUpload

### DIFF
--- a/frontend/src/components/DocumentUpload.tsx
+++ b/frontend/src/components/DocumentUpload.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Upload, FileText, CheckCircle, AlertCircle, X, File } from 'lucide-react';
+import { Upload, FileText, CheckCircle, AlertCircle, X, File as FileIcon } from 'lucide-react';
 
 interface UploadedDocument {
   document_id: string;
@@ -149,13 +149,13 @@ export const DocumentUpload: React.FC<DocumentUploadProps> = ({ onUploadComplete
     const extension = filename.split('.').pop()?.toLowerCase();
     switch (extension) {
       case 'pdf':
-        return <File className="w-5 h-5 text-red-500" />;
+        return <FileIcon className="w-5 h-5 text-red-500" />;
       case 'docx':
-        return <File className="w-5 h-5 text-blue-500" />;
+        return <FileIcon className="w-5 h-5 text-blue-500" />;
       case 'txt':
         return <FileText className="w-5 h-5 text-gray-500" />;
       default:
-        return <File className="w-5 h-5 text-gray-400" />;
+        return <FileIcon className="w-5 h-5 text-gray-400" />;
     }
   };
 


### PR DESCRIPTION
## Summary
- alias the lucide `File` icon to `FileIcon`
- update icon references accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a6d5fae50833099082afe4040465f