### PR TITLE
Add OrganizationService collection name test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ temp/
 test_*.py
 *_test.py
 test_*.txt
+!backend/tests/**
 
 # Documentation files (generated during development)
 CURRENT_SESSION_*.md

--- a/backend/tests/test_organization_service.py
+++ b/backend/tests/test_organization_service.py
@@ -1,0 +1,19 @@
+import uuid
+import re
+import hashlib
+from services.organization_service import OrganizationService
+
+
+def test_create_org_collection_name_deterministic():
+    service = OrganizationService(db=None)
+    org_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    result1 = service.create_org_collection_name(org_id)
+    result2 = service.create_org_collection_name(org_id)
+
+    org_str = str(org_id).replace("-", "")
+    expected_hash = hashlib.md5(org_str.encode()).hexdigest()[:8]
+    expected = f"org_{expected_hash}_docs"
+
+    assert result1 == expected
+    assert result2 == expected
+    assert re.fullmatch(r"org_[0-9a-f]{8}_docs", result1)


### PR DESCRIPTION
## Summary
- allow backend tests in .gitignore
- add unit test for OrganizationService.create_org_collection_name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6fb088748330b67e6a1453c69d4b